### PR TITLE
Add io-event and msgpack

### DIFF
--- a/shared/gemfiles/20241122/Gemfile
+++ b/shared/gemfiles/20241122/Gemfile
@@ -28,3 +28,5 @@ gem 'mysql2', force_ruby_platform: true
 gem 'bigdecimal', force_ruby_platform: true
 gem 'stringio', force_ruby_platform: true
 gem 'psych', force_ruby_platform: true
+gem 'io-event', require: 'io/event'
+gem 'msgpack', force_ruby_platform: true

--- a/shared/gemfiles/20241122/Gemfile.lock
+++ b/shared/gemfiles/20241122/Gemfile.lock
@@ -12,9 +12,11 @@ GEM
     fast-stemmer (1.0.2)
     ffi (1.17.0)
     hitimes (3.0.0)
+    io-event (1.7.4)
     json (2.8.2)
     kgio (2.11.4)
     mini_portile2 (2.8.6)
+    msgpack (1.7.5)
     mysql2 (0.5.6)
     nio4r (2.7.4)
     nokogiri (1.16.7)
@@ -64,9 +66,11 @@ DEPENDENCIES
   fast-stemmer
   ffi
   hitimes
+  io-event
   json
   kgio
   mini_portile2 (= 2.8.6)
+  msgpack
   mysql2
   nokogiri
   pg


### PR DESCRIPTION
Big picture: I'd like to have builds of msgpack and io-select without maintaining a separate branch. io-select is needed for all of the async-websocket, async-http, etc. gems and the falcon web server.

### Write a description of changes made

Added the gems `io-select` and `msgpack` to the shared bundle.